### PR TITLE
Add syntax highlighting README for vim-flavored-markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ syn region texinlinemaths start="\(\$\)\@<!\&\(\\\)\@<!\$\(\$\)\@!" end="\(\$\)\
 #### Syntax highlighting with Github flavored markdown
 
 If you are using [vim-flavored-markdown], put the following into
-''after/syntax/ghmarkdown.vim'':
+``after/syntax/ghmarkdown.vim``:
 
 ```viml
 " Enable syntax highlighting for python code blocks in Github flavored markdown


### PR DESCRIPTION
Hi, great work. I fiddled around and came up with a syntax highlighting configuration for vim using the Github flavored markdown plugin [vim-flavored-markdown](https://github.com/jtratner/vim-flavored-markdown). I just added the configuration to the README. Hope it is of help.
Cheers,
Andreas
