### PR TITLE
Support alternate kernels (R, Julia, ...)

### DIFF
--- a/notedown/main.py
+++ b/notedown/main.py
@@ -154,6 +154,9 @@ def command_line_parser():
                         action='store_true',
                         help=("run the notebook, executing the "
                               "contents of each cell"))
+    parser.add_argument('--kernel',
+                        default='python2',
+                        help=("kernel to use to run the notebook"))
     parser.add_argument('--timeout',
                         default=30,
                         type=int,

--- a/notedown/main.py
+++ b/notedown/main.py
@@ -257,6 +257,7 @@ def main(args, help=''):
                'markdown': MarkdownReader(precode='\n'.join(args.precode),
                                           magic=args.magic,
                                           match=args.match,
+                                          kernel=args.kernel,
                                           caption_comments=args.render)
                }
 

--- a/notedown/notedown.py
+++ b/notedown/notedown.py
@@ -99,7 +99,7 @@ class MarkdownReader(NotebookReader):
     """
 
     def __init__(self, code_regex=None, precode='', magic=True,
-                 match='all', caption_comments=False):
+                 kernel='python', match='all', caption_comments=False):
         """
             code_regex - Either 'fenced' or 'indented' or
                          a regular expression that matches code blocks in
@@ -116,6 +116,8 @@ class MarkdownReader(NotebookReader):
             magic      - whether to use code cell language magic, e.g.
                          put '%bash' at start of cells that have language
                          'bash'
+
+            kernel     - language kernel to use (defaults to python)
 
             match      - one of 'all', 'fenced' or 'strict' or a specific
                          language name
@@ -139,6 +141,7 @@ class MarkdownReader(NotebookReader):
 
         self.precode = precode
         self.magic = magic
+        self.kernel = kernel
 
         self.match = match
 

--- a/notedown/notedown.py
+++ b/notedown/notedown.py
@@ -369,8 +369,18 @@ class MarkdownReader(NotebookReader):
         blocks = [self.process_code_block(block) for block in all_blocks]
 
         cells = self.create_cells(blocks)
+        metadata = {}
 
-        nb = nbbase.new_notebook(cells=cells)
+        from jupyter_client import kernelspec
+        try:
+            ks = kernelspec.get_kernel_spec(self.kernel)
+            kd = ks.to_dict()
+            kd['name'] = self.kernel
+            metadata['kernelspec'] = kd
+        except kernelspec.NoSuchKernel:
+            pass
+
+        nb = nbbase.new_notebook(cells=cells, metadata=metadata)
 
         return nb
 

--- a/notedown/notedown.py
+++ b/notedown/notedown.py
@@ -437,11 +437,18 @@ class MarkdownWriter(NotebookWriter):
 
         self.langugage = 'python'
 
+    def init(self, notebook):
+        # TODO: this isn't reliable. Might need to look at
+        # language_info or create a look up between kernel names
+        # and language names.
+        self.language = notebook.metadata.kernelspec.language
+
     def write_from_json(self, notebook_json):
         notebook = v4.reads_json(notebook_json)
         return self.write(notebook)
 
     def writes(self, notebook):
+        self.init(notebook)
         body, resources = self.exporter.from_notebook_node(notebook)
         self.resources = resources
 


### PR DESCRIPTION
Resolving #24. Currently functional but requires usage with `--nomagic` and nbconvert master.

Todo:
- [x] install R kernel on my machine for testing (http://irkernel.github.io/installation/)
- [x] add a `--kernel` argument that defaults to python
- [x] set the language metadata when creating an internal notebook
  - [x] kernelspec
  - [ ] how much kernelspec do we actually want to pass?
  - [ ] language_info - _not sure this is necessary_
- [x] check whether this kernel spec is used when using `--run` - _requires nbconvert 4.1_
- [ ] allow setting metadata in a markdown yaml header?
- [x] write correct language in code attributes with MarkdownWriter
  - [ ] make more robust (currently relies on `kernelspec.language`)
- [ ] resolve `--magic` behaviour
  - [ ] make non default?
  - [ ] only allow for python kernel?
