### PR TITLE
Require jupyter instead of ipython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url='http://github.com/aaren/notedown',
     install_requires=['nbformat',
                       'nbconvert',
-                      'ipython',  # because of nbconvert
+                      'jupyter',  # because of nbconvert
                       'pandoc-attributes',
                       'six'],
     entry_points={'console_scripts': ['notedown = notedown.main:app', ]},


### PR DESCRIPTION
At the time of writing, running `ipython nbconvert` generates the following warning.

```
Subcommand `ipython nbconvert` is deprecated and will be removed in future versions.
```