### PR TITLE
Use jinja wordwrap to prevent URLs from being wrapped

### DIFF
--- a/notedown/templates/markdown.tpl
+++ b/notedown/templates/markdown.tpl
@@ -5,7 +5,7 @@
 {% endblock input %}
 
 {% block markdowncell scoped %}
-{{ cell.source | wrap_text(80) }}
+{{ cell.source | wordwrap(80, False) }}
 {% endblock markdowncell %}
 
 {% block outputs %}


### PR DESCRIPTION
Long URLs were wrapped at column 80, rendering them unusable.

Fixes aaren/notedown#49
