### PR TITLE
Add link to vim plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ For IPython your config is `ipython_notebook_config.py` in your ipython
 profile (probably `~/.ipython/profile_default`):
 
 
+### Editing in vim
+
+There is a [vim plugin][vimplug] that allows editing notebooks (ipynb files)
+directly in vim. They will be automatically converted to markdown on opening the
+file, and converted back to the original json format on writing.
+
+[vimplug]: https://github.com/goerz/ipynb_notedown.vim
+
+
 ### R-markdown
 
 You can use `notedown` to convert r-markdown as well. We just need


### PR DESCRIPTION
I created a little vim plugin that uses `notedown` in the background to enable editing ipynb files directly. The notebook files are automatically converted to markdown on reading and back to the original json format on writing.

If you think this is useful, I've added a link to the Github project for this plugin in the README in this pull request.