### PR TITLE
Add tox tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34
+envlist=py27,py36
 
 [testenv]
 deps= nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist=py27,py34
+
+[testenv]
+deps= nose
+commands=nosetests 


### PR DESCRIPTION
Use tox to run tests on python 2.7 and 3.6
