### PR TITLE
Include license file in source tarball

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license-file = LICENSE


### PR DESCRIPTION
The `LICENSE` is currently not included in the source tarball. 