### PR TITLE
fix: display_priority template is deprecatedand throws an error

### DIFF
--- a/notedown/templates/markdown.tpl
+++ b/notedown/templates/markdown.tpl
@@ -1,4 +1,4 @@
-{% extends 'display_priority.tpl' %}
+{% extends 'base/display_priority.j2' %}
 
 {% block input %}
 {{ cell | create_input_codeblock }}


### PR DESCRIPTION
```
{{ resources.deprecated("This template is deprecated, please use base/display_priority.j2") }}
{%- extends 'display_priority.j2' -%}
```

Fix for https://github.com/aaren/notedown/issues/95